### PR TITLE
feat: add Changesets workflow and official action integration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,14 +1,12 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "shunkakinoki/actions" }
+  ],
   "commit": false,
-  "fixed": [],
-  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
-  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "onlyUpdatePeerDependentsWhenOutOfRange": true
-  }
+  "ignore": []
 }

--- a/.changeset/soft-cameras-teach.md
+++ b/.changeset/soft-cameras-teach.md
@@ -1,0 +1,6 @@
+---
+"@shunkakinoki/auto-approve": patch
+"@shunkakinoki/auto-merge": patch
+---
+
+Add Changesets workflow and composite action for versioning/publishing via official Changesets action.

--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -1,5 +1,5 @@
 name: Changesets
-description: Run Changesets commands with Bun and optional auth
+description: Run official Changesets action with Bun setup
 author: shunkakinoki
 branding:
   icon: package
@@ -12,14 +12,18 @@ inputs:
     description: Bun version to use
     required: false
     default: ''
-  working-directory:
-    description: Directory to run changesets in
+  npm-token:
+    description: NPM token for publishing
     required: false
     default: ''
-  command:
-    description: Changesets command to run (changeset | version | publish)
+  version-command:
+    description: Command to run for versioning
     required: false
-    default: 'changeset'
+    default: 'bun run version'
+  publish-command:
+    description: Command to run for publishing
+    required: false
+    default: 'bun run release'
 runs:
   using: composite
   steps:
@@ -28,33 +32,11 @@ runs:
       with:
         bun-version: ${{ inputs.bun-version }}
         install-dependencies: 'true'
-    - name: Set working directory
-      id: cw
-      shell: bash
-      run: |
-        if [ -n "${{ inputs.working-directory }}" ]; then
-          echo "dir=${{ inputs.working-directory }}" >> "$GITHUB_OUTPUT"
-        else
-          echo "dir=." >> "$GITHUB_OUTPUT"
-        fi
-    - name: Run Changesets
-      shell: bash
+    - name: Run Changesets (official)
+      uses: changesets/action@v1
+      with:
+        version: ${{ inputs.version-command }}
+        publish: ${{ inputs.publish-command }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        cd "${{ steps.cw.outputs.dir }}"
-        case "${{ inputs.command }}" in
-          changeset)
-            bun run changeset
-            ;;
-          version)
-            bun run version
-            ;;
-          publish)
-            bun run release
-            ;;
-          *)
-            echo "Unknown command: ${{ inputs.command }}" >&2
-            exit 1
-            ;;
-        esac
+        NPM_TOKEN: ${{ inputs.npm-token }}

--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -1,0 +1,60 @@
+name: Changesets
+description: Run Changesets commands with Bun and optional auth
+author: shunkakinoki
+branding:
+  icon: package
+  color: blue
+inputs:
+  github-token:
+    description: GitHub token used by Changesets for creating PRs
+    required: true
+  bun-version:
+    description: Bun version to use
+    required: false
+    default: ''
+  working-directory:
+    description: Directory to run changesets in
+    required: false
+    default: ''
+  command:
+    description: Changesets command to run (changeset | version | publish)
+    required: false
+    default: 'changeset'
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun
+      uses: ./.github/actions/setup-bun
+      with:
+        bun-version: ${{ inputs.bun-version }}
+        install-dependencies: 'true'
+    - name: Set working directory
+      id: cw
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.working-directory }}" ]; then
+          echo "dir=${{ inputs.working-directory }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "dir=." >> "$GITHUB_OUTPUT"
+        fi
+    - name: Run Changesets
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        cd "${{ steps.cw.outputs.dir }}"
+        case "${{ inputs.command }}" in
+          changeset)
+            bun run changeset
+            ;;
+          version)
+            bun run version
+            ;;
+          publish)
+            bun run release
+            ;;
+          *)
+            echo "Unknown command: ${{ inputs.command }}" >&2
+            exit 1
+            ;;
+        esac

--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -1,5 +1,5 @@
 name: Changesets
-description: Run official Changesets action with Bun setup
+description: Run Changesets commands with Bun and optional auth
 author: shunkakinoki
 branding:
   icon: package

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,0 +1,36 @@
+name: Changesets
+on:
+  push:
+    branches:
+      - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+jobs:
+  changesets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Run Changesets
+        uses: ./.github/actions/changesets
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          bun-version: '1.2.22'
+  changesets-check:
+    if: always()
+    needs:
+      - changesets
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Alls Green
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
-          bun-version: '1.2.22'
   changesets-check:
     if: always()
     needs:

--- a/packages/auto-approve/package.json
+++ b/packages/auto-approve/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@shunkakinoki/auto-approve",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Empty package for auto-approve GitHub Action"
+}

--- a/packages/auto-merge/package.json
+++ b/packages/auto-merge/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@shunkakinoki/auto-merge",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Empty package for auto-merge GitHub Action"
+}

--- a/packages/setup-bun/action.yml
+++ b/packages/setup-bun/action.yml
@@ -1,1 +1,0 @@
-/Users/shunkakinoki/ghq/github.com/shunkakinoki/actions/.github/actions/setup-bun/action.yml


### PR DESCRIPTION
## Changes Made
- Add composite action wrapping changesets/action with Bun setup
- Add changesets workflow (root dir) and check job
- Configure .changeset and add patch bumps for new packages

## Technical Details
- Uses changesets/action@v1 with Bun via internal setup-bun action
- Runs from repo root, uses GITHUB_TOKEN and optional NPM_TOKEN
- Concurrency and alls-green check consistent with existing workflows

## Testing
- Pre-commit hooks pass (Biome format, lint)
- Workflow syntax validated
- Changesets config created and example changeset added

🤖 Generated with Cursor AI