### PR TITLE
fix: update changesets workflow to use PAT_TOKEN

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run Changesets
         uses: ./.github/actions/changesets
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN }}
           publish-command: ''
           create-github-releases: 'true'
           commit-mode: 'github-api'


### PR DESCRIPTION
## Changes Made
- Updated changesets workflow to use PAT_TOKEN instead of GITHUB_TOKEN
- This resolves authentication issues with the changesets action

## Technical Details
- Modified .github/workflows/changesets.yml
- Changed github-token parameter from ${{ secrets.GITHUB_TOKEN }} to ${{ secrets.PAT_TOKEN }}
- This ensures proper authentication for changesets operations

## Testing
- All pre-commit hooks pass (Biome formatting and linting)
- Pre-push hooks pass successfully
- Workflow syntax validated
- No breaking changes to existing functionality

🤖 Generated with grok-code-fast-1