### PR TITLE
chore: add VSCode workspace color settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,34 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#fa1b49",
+    "activityBar.background": "#fa1b49",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#155e02",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "commandCenter.border": "#e7e7e799",
+    "editorError.foreground": "#000000ff",
+    "editorGroup.border": "#fa1b49",
+    "editorInfo.foreground": "#000000ff",
+    "editorWarning.foreground": "#000000ff",
+    "panel.border": "#fa1b49",
+    "sash.hoverBorder": "#fa1b49",
+    "sideBar.border": "#fa1b49",
+    "statusBar.background": "#dd0531",
+    "statusBar.border": "#dd0531",
+    "statusBar.debuggingBackground": "#05ddb1",
+    "statusBar.debuggingBorder": "#05ddb1",
+    "statusBar.debuggingForeground": "#15202b",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#fa1b49",
+    "statusBarItem.remoteBackground": "#dd0531",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "tab.activeBorder": "#fa1b49",
+    "titleBar.activeBackground": "#dd0531",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.border": "#dd0531",
+    "titleBar.inactiveBackground": "#dd053199",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  }
+  // "peacock.color": "#dd0531"
+}


### PR DESCRIPTION
## Changes Made
- Add  with custom color theme overrides
- Editor-only configuration; no build or runtime impact

## Technical Details
- Biome used for formatting/linting; repo remains green
- Changes scoped to VSCode workspace settings only

## Testing
- Pre-commit and pre-push hooks passed (Biome formatting, linting)
- No application code modified

🤖 Generated with GPT-5