### PR TITLE
refactor: remove bun-version input and setup step from changesets action

### DIFF
--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -8,10 +8,6 @@ inputs:
   github-token:
     description: GitHub token used by Changesets for creating PRs
     required: true
-  bun-version:
-    description: Bun version to use
-    required: false
-    default: ''
   npm-token:
     description: NPM token for publishing
     required: false
@@ -35,11 +31,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Bun
-      uses: ./.github/actions/setup-bun
-      with:
-        bun-version: ${{ inputs.bun-version }}
-        install-dependencies: 'true'
     - name: Fetch base branch
       if: github.event_name == 'pull_request'
       shell: bash


### PR DESCRIPTION
## Changes Made
- Removed the bun-version input from action.yml as it is no longer required
- Eliminated the setup step for Bun to streamline the action's execution
- This change simplifies the configuration and focuses on essential inputs for the changesets action

## Technical Details
- Simplified the changesets composite action by removing unnecessary Bun setup
- Maintained all essential functionality while reducing complexity
- The action now has fewer inputs and runs more efficiently

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- Changesets action functionality remains intact
- No breaking changes to existing workflows using this action

🤖 Generated with Grok