### PR TITLE
chore: bump all packages to align versioning

### DIFF
--- a/.changeset/bump-all-packages.md
+++ b/.changeset/bump-all-packages.md
@@ -1,0 +1,8 @@
+---
+"@shunkakinoki/auto-approve": minor
+"@shunkakinoki/auto-merge": minor
+"@shunkakinoki/changesets": minor
+"@shunkakinoki/setup-bun": minor
+---
+
+Bump all packages to align versioning


### PR DESCRIPTION
## Changes Made
- Added changeset to bump @shunkakinoki/auto-approve from 1.0.1 to 1.1.0
- Added changeset to bump @shunkakinoki/auto-merge from 1.0.1 to 1.1.0  
- Added changeset to bump @shunkakinoki/changesets from 1.1.0 to 1.2.0
- Added changeset to bump @shunkakinoki/setup-bun from 1.1.0 to 1.2.0

## Technical Details
- Created changeset file to trigger version bumps across all packages
- Aligns package versions for consistency across the monorepo
- Uses minor version bumps to maintain semantic versioning

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- Changeset configuration validated
- No breaking changes to existing functionality

🤖 Generated with Cursor