### PR TITLE
feat: make all packages public for npm publishing

### DIFF
--- a/packages/auto-approve/CHANGELOG.md
+++ b/packages/auto-approve/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shunkakinoki/auto-approve
 
+## 1.2.0
+
+### Minor Changes
+
+- Make packages public by removing private flag and adding publishConfig
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/auto-approve/package.json
+++ b/packages/auto-approve/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@shunkakinoki/auto-approve",
-  "version": "1.1.0",
-  "private": true,
+  "version": "1.2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Empty package for auto-approve GitHub Action"
 }

--- a/packages/auto-merge/CHANGELOG.md
+++ b/packages/auto-merge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shunkakinoki/auto-merge
 
+## 1.2.0
+
+### Minor Changes
+
+- Make packages public by removing private flag and adding publishConfig
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/auto-merge/package.json
+++ b/packages/auto-merge/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@shunkakinoki/auto-merge",
-  "version": "1.1.0",
-  "private": true,
+  "version": "1.2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Empty package for auto-merge GitHub Action"
 }

--- a/packages/changesets/CHANGELOG.md
+++ b/packages/changesets/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shunkakinoki/changesets
 
+## 1.3.0
+
+### Minor Changes
+
+- Make packages public by removing private flag and adding publishConfig
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/changesets/package.json
+++ b/packages/changesets/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@shunkakinoki/changesets",
-  "version": "1.2.0",
-  "private": true,
+  "version": "1.3.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "GitHub Action to run Changesets commands with Bun and optional auth"
 }

--- a/packages/setup-bun/CHANGELOG.md
+++ b/packages/setup-bun/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shunkakinoki/setup-bun
 
+## 1.3.0
+
+### Minor Changes
+
+- Make packages public by removing private flag and adding publishConfig
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/setup-bun/package.json
+++ b/packages/setup-bun/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@shunkakinoki/setup-bun",
-  "version": "1.2.0",
-  "private": true,
+  "version": "1.3.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "GitHub Action to setup Bun runtime with dependency installation and caching"
 }


### PR DESCRIPTION
## Changes Made
- Removed 'private': true from all package.json files  
- Added 'publishConfig': {'access': 'public'} to all packages
- Bumped versions: auto-approve (1.1.0→1.2.0), auto-merge (1.1.0→1.2.0), changesets (1.2.0→1.3.0), setup-bun (1.2.0→1.3.0)
- Updated changelogs with release notes for all packages

## Technical Details
- Modified package.json files for all 4 GitHub Action packages
- Changesets handled version bumping and changelog generation
- All packages now configured for public npm publishing
- No breaking changes to existing functionality

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- No code changes that affect functionality
- Package version bumps follow semantic versioning
- Ready for automated publishing workflow

🤖 Generated with Cursor