### PR TITLE
feat: add publish-packages input to changesets action

### DIFF
--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: Validate pull request by checking changeset status
     required: false
     default: 'false'
+  publish-packages:
+    description: Publish packages after changeset publish
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -56,5 +60,14 @@ runs:
         createGithubReleases: ${{ inputs.create-github-releases }}
         commitMode: ${{ inputs.commit-mode }}
       env:
+        GITHUB_SHA: ${{ github.sha }}
+        GITHUB_REF: ${{ github.ref }}
+        GITHUB_HEAD_REF: ${{ github.head_ref }}
+        GITHUB_BASE_REF: ${{ github.base_ref }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        GITHUB_EVENT_NUMBER: ${{ github.event_number }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+        PUBLISH_PACKAGES: ${{ inputs.publish-packages }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}


### PR DESCRIPTION
## Changes Made
- Added publish-packages input parameter to changesets GitHub Action with default value 'true'
- Included comprehensive GitHub environment variables (GITHUB_SHA, GITHUB_REF, etc.) for enhanced context
- Added PUBLISH_PACKAGES environment variable to make the input available to downstream steps

## Technical Details
- Extends the existing changesets action.yml with new input parameter
- Environment variables provide full GitHub context for changeset operations
- Maintains backward compatibility with existing workflows
- Follows GitHub Actions best practices for input handling

## Testing
- All pre-commit hooks pass (Biome formatting and linting)
- Pre-push hooks pass (additional linting verification)
- Changes maintain existing functionality while adding new capabilities
- No breaking changes to existing changeset workflows

🤖 Generated with grok-code-fast-1