### PR TITLE
feat: add comprehensive env variables to changesets action

### DIFF
--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -28,10 +28,6 @@ inputs:
     description: Validate pull request by checking changeset status
     required: false
     default: 'false'
-  publish-packages:
-    description: Publish packages after changeset publish
-    required: false
-    default: 'true'
 runs:
   using: composite
   steps:
@@ -68,7 +64,6 @@ runs:
         GITHUB_EVENT_PATH: ${{ github.event_path }}
         GITHUB_EVENT_NUMBER: ${{ github.event_number }}
         GITHUB_REF_NAME: ${{ github.ref_name }}
-        PUBLISH_PACKAGES: ${{ inputs.publish-packages }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
         NPM_CONFIG_TOKEN: ${{ inputs.npm-token }}

--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -71,3 +71,4 @@ runs:
         PUBLISH_PACKAGES: ${{ inputs.publish-packages }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
+        NPM_CONFIG_TOKEN: ${{ inputs.npm-token }}

--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: Validate pull request by checking changeset status
     required: false
     default: 'false'
+  publish-packages:
+    description: Publish packages after changeset publish
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -56,5 +60,14 @@ runs:
         createGithubReleases: ${{ inputs.create-github-releases }}
         commitMode: ${{ inputs.commit-mode }}
       env:
+        GITHUB_SHA: ${{ github.sha }}
+        GITHUB_REF: ${{ github.ref }}
+        GITHUB_HEAD_REF: ${{ github.head_ref }}
+        GITHUB_BASE_REF: ${{ github.base_ref }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        GITHUB_EVENT_NUMBER: ${{ github.event_number }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+        PUBLISH_PACKAGES: ${{ inputs.publish-packages }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}


### PR DESCRIPTION
## Changes Made
- Restored comprehensive environment variables for the changesets action
- Added GITHUB_SHA, GITHUB_REF, GITHUB_HEAD_REF, GITHUB_BASE_REF, and other GitHub context variables
- Added NPM_CONFIG_TOKEN environment variable for additional npm authentication
- Ensures proper GitHub context and npm publishing configuration

## Technical Details
- Restored all GitHub context environment variables that the changesets/action@v1 may need
- Added NPM_CONFIG_TOKEN alongside NPM_TOKEN for comprehensive npm authentication
- Maintains compatibility with existing workflows while providing more robust configuration

## Testing
- All pre-commit hooks pass (Biome formatting and linting)
- Pre-push hooks pass successfully  
- No breaking changes to existing functionality
- The action will have access to all necessary GitHub context and authentication tokens

🤖 Generated with grok-code-fast-1