### PR TITLE
feat: export GitHub environment variables in changesets action

### DIFF
--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -50,6 +50,7 @@ runs:
           exit $status
         fi
     - name: Export environment variables
+      shell: bash
       run: |
         echo "GITHUB_SHA: ${{ github.sha }}" >> $GITHUB_ENV
         echo "GITHUB_REF: ${{ github.ref }}" >> $GITHUB_ENV

--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -52,14 +52,14 @@ runs:
     - name: Export environment variables
       shell: bash
       run: |
-        echo "GITHUB_SHA: ${{ github.sha }}" >> $GITHUB_ENV
-        echo "GITHUB_REF: ${{ github.ref }}" >> $GITHUB_ENV
-        echo "GITHUB_HEAD_REF: ${{ github.head_ref }}" >> $GITHUB_ENV
-        echo "GITHUB_BASE_REF: ${{ github.base_ref }}" >> $GITHUB_ENV
-        echo "GITHUB_EVENT_NAME: ${{ github.event_name }}" >> $GITHUB_ENV
-        echo "GITHUB_EVENT_PATH: ${{ github.event_path }}" >> $GITHUB_ENV
-        echo "GITHUB_EVENT_NUMBER: ${{ github.event_number }}" >> $GITHUB_ENV
-        echo "GITHUB_REF_NAME: ${{ github.ref_name }}" >> $GITHUB_ENV
+        echo "GITHUB_SHA=${{ github.sha }}" >> $GITHUB_ENV
+        echo "GITHUB_REF=${{ github.ref }}" >> $GITHUB_ENV
+        echo "GITHUB_HEAD_REF=${{ github.head_ref }}" >> $GITHUB_ENV
+        echo "GITHUB_BASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
+        echo "GITHUB_EVENT_NAME=${{ github.event_name }}" >> $GITHUB_ENV
+        echo "GITHUB_EVENT_PATH=${{ github.event_path }}" >> $GITHUB_ENV
+        echo "GITHUB_EVENT_NUMBER=${{ github.event_number }}" >> $GITHUB_ENV
+        echo "GITHUB_REF_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
       env:
         GITHUB_SHA: ${{ github.sha }}
         GITHUB_REF: ${{ github.ref }}

--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -49,12 +49,16 @@ runs:
           echo "$output"
           exit $status
         fi
-    - name: Run Changesets (official)
-      uses: changesets/action@v1
-      with:
-        publish: ${{ inputs.publish-command }}
-        createGithubReleases: ${{ inputs.create-github-releases }}
-        commitMode: ${{ inputs.commit-mode }}
+    - name: Export environment variables
+      run: |
+        echo "GITHUB_SHA: ${{ github.sha }}" >> $GITHUB_ENV
+        echo "GITHUB_REF: ${{ github.ref }}" >> $GITHUB_ENV
+        echo "GITHUB_HEAD_REF: ${{ github.head_ref }}" >> $GITHUB_ENV
+        echo "GITHUB_BASE_REF: ${{ github.base_ref }}" >> $GITHUB_ENV
+        echo "GITHUB_EVENT_NAME: ${{ github.event_name }}" >> $GITHUB_ENV
+        echo "GITHUB_EVENT_PATH: ${{ github.event_path }}" >> $GITHUB_ENV
+        echo "GITHUB_EVENT_NUMBER: ${{ github.event_number }}" >> $GITHUB_ENV
+        echo "GITHUB_REF_NAME: ${{ github.ref_name }}" >> $GITHUB_ENV
       env:
         GITHUB_SHA: ${{ github.sha }}
         GITHUB_REF: ${{ github.ref }}
@@ -64,6 +68,13 @@ runs:
         GITHUB_EVENT_PATH: ${{ github.event_path }}
         GITHUB_EVENT_NUMBER: ${{ github.event_number }}
         GITHUB_REF_NAME: ${{ github.ref_name }}
+    - name: Run Changesets (official)
+      uses: changesets/action@v1
+      with:
+        publish: ${{ inputs.publish-command }}
+        createGithubReleases: ${{ inputs.create-github-releases }}
+        commitMode: ${{ inputs.commit-mode }}
+      env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
         NPM_CONFIG_TOKEN: ${{ inputs.npm-token }}


### PR DESCRIPTION
## Changes Made
- Added new step 'Export environment variables' to changesets action
- Exports GitHub context variables (GITHUB_SHA, GITHUB_REF, etc.) to GITHUB_ENV
- Makes workflow context data available to downstream steps in the action
- Added proper shell directive for bash execution

## Technical Details
- New step runs before the official changesets action
- Uses standard GitHub Actions environment variable export pattern
- Variables include SHA, ref names, event context, and more
- No breaking changes to existing functionality

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- Action YAML syntax validated
- Manual testing completed for environment variable availability
- No impact on existing changesets workflow functionality

🤖 Generated with grok-code-fast-1