### PR TITLE
feat: add version-command input to changesets action

### DIFF
--- a/.github/actions/changesets/action.yml
+++ b/.github/actions/changesets/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: Command to run for publishing
     required: false
     default: 'bun run release'
+  version-command:
+    description: Command to run for versioning
+    required: false
+    default: 'bun run version'
   create-github-releases:
     description: Create GitHub releases after publish (tags + releases)
     required: false
@@ -73,6 +77,7 @@ runs:
       uses: changesets/action@v1
       with:
         publish: ${{ inputs.publish-command }}
+        version: ${{ inputs.version-command }}
         createGithubReleases: ${{ inputs.create-github-releases }}
         commitMode: ${{ inputs.commit-mode }}
       env:


### PR DESCRIPTION
## Changes Made
- Added `version-command` input parameter to the changesets GitHub Action
- Allows customizing the versioning command instead of using the hardcoded default
- Maintains backward compatibility with existing workflows
- Default value set to `bun run version` to match current behavior

## Technical Details
- Added input definition with description and default value
- Updated the changesets/action usage to include the new parameter
- Follows existing action.yml structure and patterns
- No breaking changes to existing functionality

## Testing
- All pre-commit hooks pass (Biome formatting and linting)
- Action syntax validated
- No breaking changes to existing usage patterns
- Ready for integration testing in CI/CD pipelines

🤖 Generated with Cursor