### PR TITLE
feat(setup-bun): use --frozen-lockfile

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -40,4 +40,4 @@ runs:
         if [ -n "${{ inputs.working-directory }}" ]; then
           cd "${{ inputs.working-directory }}"
         fi
-        bun install
+        bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Switch the install step in `setup-bun` from `bun install` to `bun install --frozen-lockfile`
- Catch package.json/bun.lock drift (e.g. dependabot PRs that forget to regenerate the lockfile) at the install step
- Previously such drift was only caught later in Docker builds that already passed `--frozen-lockfile`, surfacing as `error: lockfile had changes, but lockfile is frozen` deep into the matrix

## Test plan
- [ ] Caller repos with synced lockfiles install green
- [ ] A caller repo with intentional drift fails fast with the frozen-lockfile error