### PR TITLE
chore: bump rharkor/caching-for-turbo to v2.4.2 (node24)

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -30,7 +30,7 @@ runs:
         bun-version: ${{ inputs.bun-version }}
     - name: Cache for Turbo
       if: inputs.enable-turbo-cache == 'true'
-      uses: rharkor/caching-for-turbo@v2.2.1
+      uses: rharkor/caching-for-turbo@v2.4.2
       with:
         cache-prefix: turbo-
     - name: Install dependencies


### PR DESCRIPTION
Bumps rharkor/caching-for-turbo from v2.2.1 (node20) to v2.4.2 (node24) in the setup-bun composite action.

GitHub deprecates Node.js 20 action runtimes on June 16, 2026 - actions will be forced onto Node 24. v2.4.2 declares `using: node24`, clearing the deprecation warnings emitted by every consuming workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)